### PR TITLE
feat: support Codex CLI runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Programmable AI Team OS** — 本地可编程 AI 团队操作系统。
 > 你设定 Goal，AI 自动配备 Team，团队自己设计 Workflow，系统持续沉淀经验。
-> Agent 能力由 **Cursor CLI** 驱动，无需登录、无需 MCP、数据 100% 本地存储。
+> Agent 能力由 **Cursor CLI / Codex CLI** 驱动，无需 MCP、数据 100% 本地存储。
 
 ## ✨ 特性
 
@@ -14,16 +14,17 @@
 - 📝 **Tasks 管理** — 频道内 Tasks Tab + 全局 Kanban 看板 + 状态变更系统消息
 - 🔍 **全文搜索 / 收藏 / 全局 Threads 聚合**
 - 💾 **100% 本地** — SQLite 存储在 `~/.slark/slark.db`，不经任何云端服务器
-- 🛠️ **适配器架构** — MVP 专注 Cursor CLI，后续可扩展 Codex / Claude Code / 其他 runtime
+- 🛠️ **适配器架构** — 支持 Cursor CLI / Cursor SDK / Codex CLI，后续可扩展 Claude Code / 其他 runtime
 
 ## 🚀 快速开始
 
 ### 前置
 
 - **Node.js ≥ 20**, **pnpm ≥ 10**
-- **[Cursor CLI](https://cursor.sh)** (`cursor-agent`) 已安装并登录
-  - MVP 当前唯一支持的 Runtime
-  - 其他 runtime（Codex / Claude / Kimi / Copilot / Gemini）在 UI 中标为 "coming soon"
+- 至少一个本地 coding runtime 已安装并登录：
+  - **Codex CLI** (`codex`)
+  - **[Cursor CLI](https://cursor.sh)** (`cursor-agent`) 或 Settings 中配置 Cursor SDK API key
+  - 其他 runtime（Claude / Kimi / Copilot / Gemini）在 UI 中标为 "coming soon"
 
 ### 启动
 
@@ -72,7 +73,7 @@ pnpm format          # Prettier
                                                ↓
                               ┌────────────┬────────────────┐
                               │  SQLite    │  CLI Bridge    │
-                              │ ~/.slark   │  cursor-agent  │
+                              │ ~/.slark   │  codex/cursor  │
                               │ /slark.db  │  spawn + NDJSON│
                               └────────────┴────────────────┘
 ```

--- a/packages/server/scripts/verify-sdk-adapter.ts
+++ b/packages/server/scripts/verify-sdk-adapter.ts
@@ -15,9 +15,10 @@ import { loadDotenv, configureCursorRipgrep } from '../src/load-env.js';
 const envLoad = loadDotenv();
 const rgConfig = configureCursorRipgrep();
 
-import { createCursorAdapter } from '../src/agents/adapter-factory.js';
+import { createCodexAdapter, createCursorAdapter } from '../src/agents/adapter-factory.js';
 import { CursorSdkAdapter } from '../src/agents/cursor-sdk-adapter.js';
 import { CursorAdapter } from '../src/agents/cursor-adapter.js';
+import { CodexAdapter } from '../src/agents/codex-adapter.js';
 import { summarizeToolArgs } from '../src/agents/summarize-tool-args.js';
 
 if (envLoad.loaded) {
@@ -60,10 +61,18 @@ console.log('1. adapter-factory 选择');
   expect(sdk instanceof CursorSdkAdapter, 'SLARK_CURSOR_BACKEND=sdk → CursorSdkAdapter');
   expect(sdk.name === 'cursor-sdk', 'SDK adapter name === cursor-sdk');
   expect(typeof sdk.runDirect === 'function', 'SDK adapter 实现 runDirect');
-  expect(typeof (cli as { runDirect?: unknown }).runDirect === 'undefined', 'CLI adapter 不实现 runDirect');
+  expect(
+    typeof (cli as { runDirect?: unknown }).runDirect === 'undefined',
+    'CLI adapter 不实现 runDirect',
+  );
 
   if (orig === undefined) delete process.env.SLARK_CURSOR_BACKEND;
   else process.env.SLARK_CURSOR_BACKEND = orig;
+
+  const codex = createCodexAdapter();
+  expect(codex instanceof CodexAdapter, 'createCodexAdapter() → CodexAdapter');
+  expect(codex.name === 'codex', 'Codex adapter name === codex');
+  expect(typeof codex.checkInstallation === 'function', 'Codex adapter 实现 checkInstallation');
 }
 
 console.log('\n2. CursorSdkAdapter checkInstallation');

--- a/packages/server/src/agents/adapter-factory.ts
+++ b/packages/server/src/agents/adapter-factory.ts
@@ -15,10 +15,22 @@
 
 import { CursorAdapter } from './cursor-adapter.js';
 import { CursorSdkAdapter } from './cursor-sdk-adapter.js';
+import { CodexAdapter } from './codex-adapter.js';
+import type { Runtime } from '@slark/shared';
 import type { CLIAdapter } from './types.js';
 
 export function createCursorAdapter(): CLIAdapter {
   const backend = (process.env.SLARK_CURSOR_BACKEND ?? 'cli').toLowerCase();
   if (backend === 'sdk') return new CursorSdkAdapter();
   return new CursorAdapter();
+}
+
+export function createCodexAdapter(): CLIAdapter {
+  return new CodexAdapter();
+}
+
+export function createAdapterForRuntime(runtime: Runtime): CLIAdapter | null {
+  if (runtime === 'cursor') return createCursorAdapter();
+  if (runtime === 'codex') return createCodexAdapter();
+  return null;
 }

--- a/packages/server/src/agents/codex-adapter.ts
+++ b/packages/server/src/agents/codex-adapter.ts
@@ -1,0 +1,227 @@
+/**
+ * Codex CLI adapter.
+ *
+ * CLI: codex exec --json
+ * Output: JSONL events written to stdout.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import type {
+  AdapterCapabilities,
+  BuildCommandParams,
+  CLIAdapter,
+  CLIEvent,
+  SpawnSpec,
+} from './types.js';
+
+const execFileAsync = promisify(execFile);
+
+const REASONING_ALIASES: Record<string, string> = {
+  'extra-high': 'xhigh',
+  max: 'xhigh',
+};
+
+export class CodexAdapter implements CLIAdapter {
+  readonly name = 'codex';
+
+  readonly capabilities: AdapterCapabilities = {
+    supportsTextDelta: false,
+    supportsThinking: false,
+    supportsWorkingDirectory: true,
+    supportsEnvVars: true,
+    supportsModelSelection: true,
+    supportsReasoningEffort: true,
+    supportsStdinContext: true,
+  };
+
+  async checkInstallation() {
+    try {
+      const { stdout: version } = await execFileAsync('codex', ['--version'], {
+        timeout: 3000,
+      });
+      const { stdout: path } = await execFileAsync('which', ['codex'], {
+        timeout: 3000,
+      });
+      return {
+        installed: true,
+        version: version.trim(),
+        path: path.trim(),
+      };
+    } catch (e) {
+      return { installed: false, error: (e as Error).message };
+    }
+  }
+
+  buildCommand(params: BuildCommandParams): SpawnSpec {
+    const args: string[] = [
+      '-s',
+      params.permissive ? 'workspace-write' : 'read-only',
+      '-a',
+      'never',
+      'exec',
+      '--json',
+      '--ephemeral',
+      '--skip-git-repo-check',
+      '--color',
+      'never',
+    ];
+
+    if (params.workingDirectory) {
+      args.push('-C', params.workingDirectory);
+    }
+
+    if (params.model) {
+      args.push('-m', params.model);
+    }
+
+    if (params.reasoning) {
+      const effort = REASONING_ALIASES[params.reasoning] ?? params.reasoning;
+      args.push('-c', `model_reasoning_effort="${effort}"`);
+    }
+
+    args.push(params.prompt);
+
+    return {
+      command: 'codex',
+      args,
+      env: params.envVars,
+      stdin: params.stdinContext,
+    };
+  }
+
+  parseLine(line: string): CLIEvent[] {
+    if (!line.trim()) return [];
+
+    let obj: unknown;
+    try {
+      obj = JSON.parse(line);
+    } catch {
+      return [];
+    }
+    if (!obj || typeof obj !== 'object') return [];
+    const o = obj as Record<string, unknown>;
+
+    switch (o.type) {
+      case 'thread.started':
+        return [
+          {
+            type: 'session.started',
+            session_id: String(o.thread_id ?? 'unknown'),
+          },
+        ];
+
+      case 'turn.started':
+        return [];
+
+      case 'item.started':
+        return this.parseItemStarted(o.item);
+
+      case 'item.completed':
+        return this.parseItemCompleted(o.item);
+
+      case 'turn.completed': {
+        const usage = o.usage as Record<string, unknown> | undefined;
+        return [
+          {
+            type: 'session.completed',
+            usage: usage
+              ? {
+                  input_tokens: asNumber(usage.input_tokens),
+                  cached_input_tokens: asNumber(usage.cached_input_tokens),
+                  output_tokens: asNumber(usage.output_tokens),
+                  extra: {
+                    reasoning_output_tokens: usage.reasoning_output_tokens,
+                  },
+                }
+              : undefined,
+          },
+        ];
+      }
+
+      case 'turn.failed':
+      case 'error':
+        return [
+          {
+            type: 'error',
+            message: stringifyMessage(o.message ?? o.error ?? 'codex error'),
+            code: typeof o.code === 'string' ? o.code : 'codex_error',
+          },
+        ];
+
+      default:
+        return [];
+    }
+  }
+
+  async getSupportedModels(): Promise<string[]> {
+    return [
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex',
+      'gpt-5.3-codex-spark',
+      'gpt-5.2',
+    ];
+  }
+
+  private parseItemStarted(item: unknown): CLIEvent[] {
+    if (!item || typeof item !== 'object') return [];
+    const i = item as Record<string, unknown>;
+    if (i.type !== 'command_execution') return [];
+    return [
+      {
+        type: 'tool.started',
+        call_id: String(i.id ?? ''),
+        tool: 'shell',
+        args: { command: String(i.command ?? '') },
+      },
+    ];
+  }
+
+  private parseItemCompleted(item: unknown): CLIEvent[] {
+    if (!item || typeof item !== 'object') return [];
+    const i = item as Record<string, unknown>;
+
+    if (i.type === 'agent_message') {
+      return [
+        {
+          type: 'text.completed',
+          text: String(i.text ?? ''),
+        },
+      ];
+    }
+
+    if (i.type === 'command_execution') {
+      return [
+        {
+          type: 'tool.completed',
+          call_id: String(i.id ?? ''),
+          tool: 'shell',
+          success: typeof i.exit_code === 'number' ? i.exit_code === 0 : i.status === 'completed',
+          result: String(i.aggregated_output ?? i.output ?? ''),
+          exit_code: asNumber(i.exit_code),
+        },
+      ];
+    }
+
+    return [];
+  }
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined;
+}
+
+function stringifyMessage(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value instanceof Error) return value.message;
+  if (value && typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return 'codex error';
+    }
+  }
+  return String(value);
+}

--- a/packages/server/src/agents/engine.ts
+++ b/packages/server/src/agents/engine.ts
@@ -35,7 +35,7 @@ import { buildContext } from './context-builder.js';
 import { ActivityRecorder } from './activity-recorder.js';
 import { concurrencyQueue } from './queue.js';
 import { runWithAdapter } from './runner.js';
-import { createCursorAdapter } from './adapter-factory.js';
+import { createAdapterForRuntime } from './adapter-factory.js';
 import type { CLIAdapter, CLIEvent } from './types.js';
 
 // Sprint 3 CP3：活跃 agent_runs 的 AbortController，支持 /abort 与 workflow override 时
@@ -64,18 +64,10 @@ export function abortChannelAgentRuns(db: Database, channelId: string): number {
   return count;
 }
 
-// Runtime 注册表：MVP 只实装 cursor。
-//
-// Sprint 4 ext (S-1)：cursor 后端可选 spawn cursor-agent 子进程（默认）/ 直接走 @cursor/sdk。
-// 实际 adapter 选择由 createCursorAdapter() 根据 SLARK_CURSOR_BACKEND 决定，两条路径都满足
-// CLIAdapter 契约（前者用 buildCommand+parseLine，后者用 runDirect），上层 runWithAdapter 自动 dispatch。
-const ADAPTERS: Partial<Record<Runtime, () => CLIAdapter>> = {
-  cursor: createCursorAdapter,
-};
-
+// Runtime registry. Cursor can use either cursor-agent (default) or @cursor/sdk;
+// Codex uses the local `codex exec --json` CLI path.
 export function getAdapterFor(runtime: Runtime): CLIAdapter | null {
-  const factory = ADAPTERS[runtime];
-  return factory ? factory() : null;
+  return createAdapterForRuntime(runtime);
 }
 
 export interface TriggerContext {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -84,7 +84,7 @@ export interface RuntimeMeta {
 
 export const RUNTIME_REGISTRY: RuntimeMeta[] = [
   { id: 'cursor', label: 'Cursor CLI', available: true },
-  { id: 'codex', label: 'Codex CLI', available: false, note: 'coming soon' },
+  { id: 'codex', label: 'Codex CLI', available: true },
   { id: 'claude', label: 'Claude Code', available: false, note: 'coming soon' },
   { id: 'kimi', label: 'Kimi CLI', available: false, note: 'coming soon' },
   { id: 'copilot', label: 'Copilot CLI', available: false, note: 'coming soon' },

--- a/packages/web/src/components/BuildTeamDialog.tsx
+++ b/packages/web/src/components/BuildTeamDialog.tsx
@@ -17,7 +17,7 @@
  */
 
 import { useEffect, useState } from 'react';
-import type { Project, TeamSuggestion } from '@slark/shared';
+import type { Project, Runtime, TeamSuggestion } from '@slark/shared';
 import { GOAL_MAX_LENGTH } from '@slark/shared';
 import {
   createAgent,
@@ -103,7 +103,7 @@ export function BuildTeamDialog({ open, onClose, project, onCreated }: Props) {
           createAgent({
             name: ensureUniqueName(a.name),
             description: a.description,
-            runtime: (a.runtime || 'cursor') as 'cursor',
+            runtime: (a.runtime || 'cursor') as Runtime,
             model: a.model || undefined,
             reasoning: a.reasoning,
             thinking: a.thinking ?? null,

--- a/packages/web/src/pages/WelcomePage.tsx
+++ b/packages/web/src/pages/WelcomePage.tsx
@@ -5,7 +5,7 @@
  *   - **无 Project**：显示 CTA "Create your first Project"
  *   - **有 Project**：自动 redirect 到第一个 Project 的 `/p/{firstProject.name}`
  *     （ProjectIndexPage 会进一步跳到第一个 channel）
- *   - cursor-agent 未装时显示黄色警告条
+ *   - Cursor / Codex backend 都不可用时显示黄色警告条
  *
  * Project 内的 channel/agent 列表移到 ProjectIndexPage。
  */
@@ -31,9 +31,12 @@ export function WelcomePage() {
   }, []);
 
   const cursor = runtimes.find((r) => r.id === 'cursor');
+  const codex = runtimes.find((r) => r.id === 'codex');
   const cliReady = cursor?.installed;
   const sdkReady = cursorBackend?.backend === 'sdk' && cursorBackend?.hasApiKey;
   const cursorReady = cliReady || sdkReady;
+  const codexReady = Boolean(codex?.installed && codex?.enabled_in_slark);
+  const codingRuntimeReady = cursorReady || codexReady;
 
   // 等 store 加载完成再判断（否则刷新会闪一下 CTA）
   if (!projectsLoaded) {
@@ -59,12 +62,15 @@ export function WelcomePage() {
           Programmable AI Team OS — set a goal, AI configures a team, team designs its own workflow.
         </p>
 
-        {!cursorReady && (
+        {!codingRuntimeReady && (
           <div className="mb-6 p-4 bg-accent-yellow border-2 border-black rounded">
-            <div className="font-bold mb-1">⚠ Cursor backend not configured</div>
+            <div className="font-bold mb-1">⚠ Coding runtime not configured</div>
             <div className="text-sm space-y-1.5">
-              <div>选一种方式让 Slark 调用 Cursor：</div>
+              <div>选一种方式让 Slark 调用本地 coding agent：</div>
               <ul className="list-disc list-inside space-y-0.5 text-[13px]">
+                <li>
+                  本机安装 <code className="font-mono">codex</code> 并登录（Codex CLI）
+                </li>
                 <li>
                   本机安装 <code className="font-mono">cursor-agent</code> 并登录（默认 CLI
                   模式，零配置）


### PR DESCRIPTION
Hi, thanks for the careful review. I narrowed this draft PR to the adapter-only scope you suggested.

What changed in this revision:
- Added a `CodexAdapter` backed by `codex exec --json`.
- Wired Codex into the existing adapter/runtime lookup for regular agents.
- Enabled `runtime: "codex"` in the shared runtime registry and widened the team build UI type so Codex agents can be created.
- Updated the README and welcome-page runtime wording without adding a Codex-ready banner.
- Added Codex adapter coverage to the existing adapter smoke script.

Review feedback addressed:
- `command_execution.success` now prefers numeric `exit_code` when present.
- Removed the dangerous Codex sandbox/approval bypass flag; the adapter now uses workspace/read-only sandbox plus `approval_policy=never`.
- Removed the system-agent fallback changes and Team Architect prompt changes from this PR so they can be handled separately if needed.

Local verification:
- `npm exec --yes -- pnpm typecheck`
- `npm exec --yes -- pnpm build:server`
- `npm exec --yes -- pnpm build:web`
- `npm exec --yes -- tsx packages/server/scripts/verify-sdk-adapter.ts`
- `npm exec --yes -- prettier --check packages/server/src/agents/codex-adapter.ts packages/server/src/agents/adapter-factory.ts packages/server/scripts/verify-sdk-adapter.ts`
- `git diff --check`
- `codex -s workspace-write -a never exec --help`

Note: this stays intentionally draft/early because the Codex JSONL event surface may need more coverage as real usage expands.
