### PR TITLE
feat: add Codex system agent fallback

### DIFF
--- a/packages/server/src/agents/adapter-factory.ts
+++ b/packages/server/src/agents/adapter-factory.ts
@@ -35,20 +35,52 @@ export function createAdapterForRuntime(runtime: Runtime): CLIAdapter | null {
   return null;
 }
 
-export async function createSystemAdapter(): Promise<CLIAdapter> {
+/**
+ * 系统 agent 的 runtime 检测结果。
+ *
+ * Review B-3：把 `install` 一起返回，调用方可以直接复用，无需再次调用
+ * `adapter.checkInstallation()`。这避免了 SDK 模式下每个 system agent 都
+ * 再发一次 `Cursor.me()` 网络调用。
+ *
+ * Review B-4：当 cursor 与 codex 都不可用时，`noRuntimeAvailable=true` 让
+ * 调用方明确知晓"两个 runtime 都没装"，可以记录 warn 日志而不是无声跳过。
+ */
+export interface SystemAdapterPick {
+  adapter: CLIAdapter;
+  install: {
+    installed: boolean;
+    version?: string;
+    path?: string;
+    error?: string;
+  };
+  /** cursor 与 codex 都未安装且未通过 SLARK_SYSTEM_RUNTIME 显式指定时为 true */
+  noRuntimeAvailable?: boolean;
+}
+
+export async function createSystemAdapter(): Promise<SystemAdapterPick> {
   const configured = (process.env.SLARK_SYSTEM_RUNTIME ?? '').toLowerCase();
-  if (configured === 'cursor') return createCursorAdapter();
-  if (configured === 'codex') return createCodexAdapter();
+  if (configured === 'cursor') {
+    const adapter = createCursorAdapter();
+    return { adapter, install: await adapter.checkInstallation() };
+  }
+  if (configured === 'codex') {
+    const adapter = createCodexAdapter();
+    return { adapter, install: await adapter.checkInstallation() };
+  }
 
   const cursor = createCursorAdapter();
   const cursorInstall = await cursor.checkInstallation();
-  if (cursorInstall.installed) return cursor;
+  if (cursorInstall.installed) {
+    return { adapter: cursor, install: cursorInstall };
+  }
 
   const codex = createCodexAdapter();
   const codexInstall = await codex.checkInstallation();
-  if (codexInstall.installed) return codex;
+  if (codexInstall.installed) {
+    return { adapter: codex, install: codexInstall };
+  }
 
-  return cursor;
+  return { adapter: cursor, install: cursorInstall, noRuntimeAvailable: true };
 }
 
 export function runtimeForAdapter(adapter: CLIAdapter): Runtime {

--- a/packages/server/src/agents/adapter-factory.ts
+++ b/packages/server/src/agents/adapter-factory.ts
@@ -34,3 +34,23 @@ export function createAdapterForRuntime(runtime: Runtime): CLIAdapter | null {
   if (runtime === 'codex') return createCodexAdapter();
   return null;
 }
+
+export async function createSystemAdapter(): Promise<CLIAdapter> {
+  const configured = (process.env.SLARK_SYSTEM_RUNTIME ?? '').toLowerCase();
+  if (configured === 'cursor') return createCursorAdapter();
+  if (configured === 'codex') return createCodexAdapter();
+
+  const cursor = createCursorAdapter();
+  const cursorInstall = await cursor.checkInstallation();
+  if (cursorInstall.installed) return cursor;
+
+  const codex = createCodexAdapter();
+  const codexInstall = await codex.checkInstallation();
+  if (codexInstall.installed) return codex;
+
+  return cursor;
+}
+
+export function runtimeForAdapter(adapter: CLIAdapter): Runtime {
+  return adapter.name === 'codex' ? 'codex' : 'cursor';
+}

--- a/packages/server/src/system-agents/coach.ts
+++ b/packages/server/src/system-agents/coach.ts
@@ -20,7 +20,7 @@
 import { COACH_NEGATIVE_THRESHOLD, COACH_TIMEOUT_MS, EVALUATOR_WINDOW_MS } from '@slark/shared';
 import type { Agent, AgentFeedback, AgentObservation } from '@slark/shared';
 import type { Database } from 'better-sqlite3';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import { createSystemAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 import {
   agentRepo,
@@ -56,7 +56,7 @@ export async function runCoachOnce(
     proposals_created: 0,
     skipped: [],
   };
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const install = await adapter.checkInstallation();
   if (!install.installed) return summary;
 
@@ -108,7 +108,7 @@ export async function runCoachForAgent(
   const observations = observationRepo.listByAgent(db, agent.id, { since, limit: 50 });
   if (observations.length === 0) return null;
 
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const prompt = buildCoachPrompt(agent, observations, hot);
   const result = await runWithAdapter(
     adapter,

--- a/packages/server/src/system-agents/coach.ts
+++ b/packages/server/src/system-agents/coach.ts
@@ -56,9 +56,19 @@ export async function runCoachOnce(
     proposals_created: 0,
     skipped: [],
   };
-  const adapter = await createSystemAdapter();
-  const install = await adapter.checkInstallation();
-  if (!install.installed) return summary;
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    logger.warn(
+      '[coach] no coding runtime available (cursor/codex both missing); skipping this tick',
+    );
+    return summary;
+  }
+  if (!install.installed) {
+    logger.warn(
+      `[coach] ${adapter.name} not available${install.error ? `: ${install.error}` : ''}; skipping this tick`,
+    );
+    return summary;
+  }
 
   const since = Date.now() - EVALUATOR_WINDOW_MS;
   const agents = agentRepo.list(db);
@@ -108,7 +118,17 @@ export async function runCoachForAgent(
   const observations = observationRepo.listByAgent(db, agent.id, { since, limit: 50 });
   if (observations.length === 0) return null;
 
-  const adapter = await createSystemAdapter();
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    logger.warn(`[coach] ${agent.name}: no coding runtime available; skipping`);
+    return null;
+  }
+  if (!install.installed) {
+    logger.warn(
+      `[coach] ${agent.name}: ${adapter.name} not available${install.error ? `: ${install.error}` : ''}; skipping`,
+    );
+    return null;
+  }
   const prompt = buildCoachPrompt(agent, observations, hot);
   const result = await runWithAdapter(
     adapter,

--- a/packages/server/src/system-agents/evaluator.ts
+++ b/packages/server/src/system-agents/evaluator.ts
@@ -92,10 +92,17 @@ export async function runEvaluatorOnce(
   db: Database,
   logger: EvaluatorLogger = consoleLog,
 ): Promise<EvaluatorRunSummary> {
-  const adapter = await createSystemAdapter();
-  const install = await adapter.checkInstallation();
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    logger.warn(
+      '[evaluator] no coding runtime available (cursor/codex both missing); skipping',
+    );
+    return { agents_evaluated: 0, observations_created: 0, skipped: [] };
+  }
   if (!install.installed) {
-    logger.info(`[evaluator] ${adapter.name} not available; skipping`);
+    logger.warn(
+      `[evaluator] ${adapter.name} not available${install.error ? `: ${install.error}` : ''}; skipping`,
+    );
     return { agents_evaluated: 0, observations_created: 0, skipped: [] };
   }
 

--- a/packages/server/src/system-agents/evaluator.ts
+++ b/packages/server/src/system-agents/evaluator.ts
@@ -21,7 +21,7 @@ import type {
   ObservationPolarity,
 } from '@slark/shared';
 import type { Database } from 'better-sqlite3';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import { createSystemAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 import type { CLIAdapter } from '../agents/types.js';
 import { agentRepo, messageRepo, observationRepo } from '../db/repos.js';
@@ -92,7 +92,7 @@ export async function runEvaluatorOnce(
   db: Database,
   logger: EvaluatorLogger = consoleLog,
 ): Promise<EvaluatorRunSummary> {
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const install = await adapter.checkInstallation();
   if (!install.installed) {
     logger.info(`[evaluator] ${adapter.name} not available; skipping`);

--- a/packages/server/src/system-agents/facilitator.ts
+++ b/packages/server/src/system-agents/facilitator.ts
@@ -48,8 +48,17 @@ export async function runFacilitator(
   input: FacilitatorInput,
   logger: FacilitatorLogger = consoleLog,
 ): Promise<FacilitatorOutput> {
-  const adapter = await createSystemAdapter();
-  const install = await adapter.checkInstallation();
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    logger.warn(
+      '[facilitator] no coding runtime available (cursor/codex both missing); falling back',
+    );
+    return {
+      ok: false,
+      fallback_reason:
+        'no coding runtime available (install cursor-agent or codex CLI, or set SLARK_SYSTEM_RUNTIME)',
+    };
+  }
   if (!install.installed) {
     return {
       ok: false,

--- a/packages/server/src/system-agents/facilitator.ts
+++ b/packages/server/src/system-agents/facilitator.ts
@@ -17,7 +17,7 @@
 
 import { FACILITATOR_TIMEOUT_MS } from '@slark/shared';
 import type { Agent, Project } from '@slark/shared';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import { createSystemAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 import { parseWorkflowYaml, WorkflowYamlError } from '../workflows/yaml-parser.js';
 
@@ -48,7 +48,7 @@ export async function runFacilitator(
   input: FacilitatorInput,
   logger: FacilitatorLogger = consoleLog,
 ): Promise<FacilitatorOutput> {
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const install = await adapter.checkInstallation();
   if (!install.installed) {
     return {

--- a/packages/server/src/system-agents/onboarder.ts
+++ b/packages/server/src/system-agents/onboarder.ts
@@ -56,16 +56,24 @@ export async function runOnboarderForProject(
     /* ignore */
   }
 
-  // 没装 cursor backend 或 workspace 完全空白 → 写一个 fallback
-  const adapter = await createSystemAdapter();
-  const install = await adapter.checkInstallation();
+  // 没装 cursor / codex 或 workspace 完全空白 → 写一个 fallback
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    logger.warn(
+      `[onboarder] ${project.name}: no coding runtime available (cursor/codex both missing); writing minimal fallback`,
+    );
+  }
   if (!install.installed || (!readme && !pkgJson && recentCommits.length === 0)) {
     onboardingRepo.upsert(db, {
       overview: project.goal,
       tech_stack: deriveQuickStack(pkgJson),
       conventions: null,
     });
-    logger.info(`[onboarder] ${project.name}: minimal fallback (no cursor backend or empty workspace)`);
+    logger.info(
+      `[onboarder] ${project.name}: minimal fallback (${
+        install.installed ? 'empty workspace' : `${adapter.name} not available`
+      })`,
+    );
     return;
   }
 

--- a/packages/server/src/system-agents/onboarder.ts
+++ b/packages/server/src/system-agents/onboarder.ts
@@ -16,7 +16,7 @@ import { resolve } from 'node:path';
 import { ONBOARDER_TIMEOUT_MS } from '@slark/shared';
 import type { Project } from '@slark/shared';
 import type { Database } from 'better-sqlite3';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import { createSystemAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 import { onboardingRepo } from '../db/repos.js';
 
@@ -57,7 +57,7 @@ export async function runOnboarderForProject(
   }
 
   // 没装 cursor backend 或 workspace 完全空白 → 写一个 fallback
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const install = await adapter.checkInstallation();
   if (!install.installed || (!readme && !pkgJson && recentCommits.length === 0)) {
     onboardingRepo.upsert(db, {

--- a/packages/server/src/system-agents/scribe.ts
+++ b/packages/server/src/system-agents/scribe.ts
@@ -29,7 +29,7 @@ import type {
   Lesson,
   LessonKind,
 } from '@slark/shared';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import { createSystemAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 import { decisionRepo, lessonRepo } from '../db/repos.js';
 import type { Database } from 'better-sqlite3';
@@ -73,7 +73,7 @@ export interface ScribeOutput {
  * Caller（runner / route）负责把结果写入 decisions / lessons 表（review_status='pending'）。
  */
 export async function runScribe(input: ScribeInput): Promise<ScribeOutput> {
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
   const install = await adapter.checkInstallation();
   if (!install.installed) {
     return emptyOutput(

--- a/packages/server/src/system-agents/scribe.ts
+++ b/packages/server/src/system-agents/scribe.ts
@@ -73,8 +73,15 @@ export interface ScribeOutput {
  * Caller（runner / route）负责把结果写入 decisions / lessons 表（review_status='pending'）。
  */
 export async function runScribe(input: ScribeInput): Promise<ScribeOutput> {
-  const adapter = await createSystemAdapter();
-  const install = await adapter.checkInstallation();
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
+  if (noRuntimeAvailable) {
+    console.warn(
+      '[scribe] no coding runtime available (cursor/codex both missing); skipping sediment',
+    );
+    return emptyOutput(
+      'no coding runtime available (install cursor-agent or codex CLI, or set SLARK_SYSTEM_RUNTIME)',
+    );
+  }
   if (!install.installed) {
     return emptyOutput(
       `${adapter.name} not available${install.error ? `: ${install.error}` : ''}`,

--- a/packages/server/src/system-agents/team-architect.ts
+++ b/packages/server/src/system-agents/team-architect.ts
@@ -31,11 +31,20 @@ export interface SuggestTeamInput {
 }
 
 export async function suggestTeam(input: SuggestTeamInput): Promise<TeamSuggestion> {
-  const adapter = await createSystemAdapter();
+  const { adapter, install, noRuntimeAvailable } = await createSystemAdapter();
   const defaultRuntime = runtimeForAdapter(adapter);
 
   // 1. 预检查：本地 coding backend 是否可用
-  const install = await adapter.checkInstallation();
+  if (noRuntimeAvailable) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      '[team-architect] no coding runtime available (cursor/codex both missing); using fallback team',
+    );
+    return fallbackTeam(
+      defaultRuntime,
+      'no coding runtime available (install cursor-agent or codex CLI, or set SLARK_SYSTEM_RUNTIME)',
+    );
+  }
   if (!install.installed) {
     return fallbackTeam(
       defaultRuntime,
@@ -238,8 +247,8 @@ function parseTeamSuggestion(raw: string, defaultRuntime: Runtime): Omit<TeamSug
     const description = typeof a.description === 'string' ? a.description.trim() : '';
     if (!name || !description) continue;
 
-    const runtime = typeof a.runtime === 'string' ? a.runtime.trim() : defaultRuntime;
-    const model = typeof a.model === 'string' ? a.model.trim() : defaultModel(defaultRuntime, 'dev');
+    const llmRuntime = typeof a.runtime === 'string' ? a.runtime.trim() : '';
+    const llmModel = typeof a.model === 'string' ? a.model.trim() : '';
     // Phase B：reasoning 5 值；老 LLM 输出可能仍写 'xhigh'，在此 normalize 到 'extra-high'。
     const reasoningRaw = typeof a.reasoning === 'string' ? a.reasoning.trim() : 'medium';
     const reasoning: ReasoningEffort =
@@ -253,18 +262,28 @@ function parseTeamSuggestion(raw: string, defaultRuntime: Runtime): Omit<TeamSug
           ? 'extra-high'
           : 'medium';
 
-    const runtimeNormalized = runtime === 'cursor' || runtime === 'codex' ? runtime : defaultRuntime;
+    // Review B-2：强制对齐当前可用 runtime。LLM 即便看到 prompt 里的 "Use runtime=codex"
+    // 也可能继续吐 "cursor"，落库后用户首次 @ 它就会遇到 "cursor backend not configured"。
+    // 这里直接覆盖为本地真实可用的 runtime，让 Team Architect 的输出永远可用。
+    const runtimeNormalized: Runtime = defaultRuntime;
+
+    // 当 LLM 输出的 runtime 与本地不一致时，它选的 model 大概率也来自另一份 catalog
+    // （例如 'claude-opus-4-7' 落到 codex runtime 上无法识别）→ 同步 fallback 到当前
+    // runtime 的默认 model；当 runtime 一致或 LLM 没给时按现状处理。
+    const runtimeMatches = llmRuntime === defaultRuntime;
+    const model = runtimeMatches && llmModel ? llmModel : defaultModel(defaultRuntime, 'dev');
 
     // Sprint 4-ext / Phase A：thinking / context 接受多种 LLM 输出变体
-    const thinking = parseThinking(a.thinking);
-    const context = parseContext(a.context);
+    // Codex CLI 不支持 thinking / context 字段，强制为 null 与 fallback 三件套保持一致。
+    const thinking = runtimeNormalized === 'codex' ? null : parseThinking(a.thinking);
+    const context = runtimeNormalized === 'codex' ? null : parseContext(a.context);
 
     agents.push({
       name,
       role: role || name,
       description,
       runtime: runtimeNormalized,
-      model: model || defaultModel(runtimeNormalized, 'dev'),
+      model,
       reasoning,
       thinking,
       context,

--- a/packages/server/src/system-agents/team-architect.ts
+++ b/packages/server/src/system-agents/team-architect.ts
@@ -3,17 +3,17 @@
  *
  * 职责：根据用户填写的 Project Goal，推导推荐的 AI 团队（3~5 个 Agent）。
  *
- * 实现：复用 CursorAdapter spawn 一次，内置 description 模板，严格 JSON 输出。
+ * 实现：复用可用的本地 coding adapter（Cursor 或 Codex）spawn 一次，内置 description 模板，严格 JSON 输出。
  *
  * 兜底（Q-2 + Review 5）：任一情况走固定三件套 Architect + Dev + Reviewer：
- *   - cursor-agent 未安装
+ *   - 本地 coding runtime 未安装
  *   - spawn 超时（独立 TEAM_ARCHITECT_TIMEOUT_MS = 30s）
  *   - 返回内容非 JSON / 解析失败 / 字段缺失
  */
 
 import { TEAM_ARCHITECT_TIMEOUT_MS } from '@slark/shared';
-import type { ReasoningEffort, TeamSuggestion, TeamSuggestionAgent } from '@slark/shared';
-import { createCursorAdapter } from '../agents/adapter-factory.js';
+import type { ReasoningEffort, Runtime, TeamSuggestion, TeamSuggestionAgent } from '@slark/shared';
+import { createSystemAdapter, runtimeForAdapter } from '../agents/adapter-factory.js';
 import { runWithAdapter } from '../agents/runner.js';
 
 // =============================================================================
@@ -31,25 +31,27 @@ export interface SuggestTeamInput {
 }
 
 export async function suggestTeam(input: SuggestTeamInput): Promise<TeamSuggestion> {
-  const adapter = createCursorAdapter();
+  const adapter = await createSystemAdapter();
+  const defaultRuntime = runtimeForAdapter(adapter);
 
-  // 1. 预检查：cursor backend 是否可用（cursor-agent / SDK 二选一，由环境变量决定）
+  // 1. 预检查：本地 coding backend 是否可用
   const install = await adapter.checkInstallation();
   if (!install.installed) {
     return fallbackTeam(
+      defaultRuntime,
       `${adapter.name} not available${install.error ? `: ${install.error}` : ''}`,
     );
   }
 
   // 2. spawn
   //
-  // 注意：Team Architect **不传 workingDirectory** 到 cursor-agent。
+  // 注意：Team Architect **不传 workingDirectory** 到 CLI runtime。
   // 原因：Create Project Step 1 时用户填的 workspace_path 可能还不存在
   // （例如准备新建一个目录作为 Project 的代码仓库）；把它作为 cwd 会让
   // spawn 立刻失败。Team Architect 只需要根据 goal + workspace_path 字符串
   // 给出推荐，不需要实际读取项目文件 —— prompt 内部已包含 workspace_path
   // 作为上下文信息，spawn cwd 留给 Node.js 默认值（process.cwd()）即可。
-  const prompt = buildTeamArchitectPrompt(input);
+  const prompt = buildTeamArchitectPrompt(input, defaultRuntime);
 
   try {
     const result = await runWithAdapter(
@@ -59,30 +61,30 @@ export async function suggestTeam(input: SuggestTeamInput): Promise<TeamSuggesti
     );
 
     if (result.timedOut) {
-      return fallbackTeam('Team Architect spawn timed out');
+      return fallbackTeam(defaultRuntime, 'Team Architect spawn timed out');
     }
     if (result.aborted) {
-      return fallbackTeam('Team Architect spawn aborted');
+      return fallbackTeam(defaultRuntime, 'Team Architect spawn aborted');
     }
     if (result.events.some((e) => e.type === 'error')) {
       const err = result.events.find((e) => e.type === 'error');
       const errMsg =
         err && err.type === 'error' ? err.message : 'Team Architect CLI error';
-      return fallbackTeam(errMsg);
+      return fallbackTeam(defaultRuntime, errMsg);
     }
 
-    const parsed = parseTeamSuggestion(result.fullText);
+    const parsed = parseTeamSuggestion(result.fullText, defaultRuntime);
     if (!parsed) {
       // S-1 调试：打印 SDK / CLI 实际返回的前 800 字符 + 长度，定位 prompt-output mismatch
       // eslint-disable-next-line no-console
       console.warn(
         `[team-architect] unparseable output; fullText.length=${result.fullText.length}, head=${JSON.stringify(result.fullText.slice(0, 800))}`,
       );
-      return fallbackTeam('Team Architect returned unparseable output');
+      return fallbackTeam(defaultRuntime, 'Team Architect returned unparseable output');
     }
     return { ...parsed, is_fallback: false };
   } catch (e) {
-    return fallbackTeam(`Team Architect spawn failed: ${(e as Error).message}`);
+    return fallbackTeam(defaultRuntime, `Team Architect spawn failed: ${(e as Error).message}`);
   }
 }
 
@@ -90,7 +92,7 @@ export async function suggestTeam(input: SuggestTeamInput): Promise<TeamSuggesti
 // Prompt 构造
 // =============================================================================
 
-function buildTeamArchitectPrompt(input: SuggestTeamInput): string {
+function buildTeamArchitectPrompt(input: SuggestTeamInput, defaultRuntime: Runtime): string {
   const hintBlock = input.workspace_hint
     ? `\n\nWorkspace hint:\n${input.workspace_hint.stack ? `- Stack: ${input.workspace_hint.stack}` : ''}${
         input.workspace_hint.readme_excerpt
@@ -98,6 +100,74 @@ function buildTeamArchitectPrompt(input: SuggestTeamInput): string {
           : ''
       }`
     : '';
+
+  const modelCatalog =
+    defaultRuntime === 'codex'
+      ? [
+          '## Model catalog (Codex CLI model IDs)',
+          '',
+          'Use runtime="codex" for every agent.',
+          '',
+          '- "gpt-5.5" — strongest general reasoning; preferred for Architect / Reviewer.',
+          '- "gpt-5.4" — strong everyday coding and balanced implementation.',
+          '- "gpt-5.4-mini" — fast lightweight work.',
+          '- "gpt-5.3-codex" — coding-optimized model for implementation and refactors.',
+          '- "gpt-5.3-codex-spark" — fast coding model for small changes.',
+          '- "gpt-5.2" — professional work fallback.',
+          '',
+          'Selection guidelines:',
+          '- Architect / Lead Reviewer → gpt-5.5; reasoning="high" or "extra-high"',
+          '- Developer / Refactorer → gpt-5.3-codex or gpt-5.4; reasoning="medium"',
+          '- Lightweight assistant → gpt-5.4-mini or gpt-5.3-codex-spark; reasoning="low"',
+          '- Codex CLI ignores thinking/context fields; set them to null.',
+        ]
+      : [
+          '## Model catalog (Cursor SDK approved IDs only)',
+          '',
+          'Use runtime="cursor" for every agent.',
+          '',
+          'Pick the right model for each role from this list — diversity is good (use vendors\' strengths together):',
+          '',
+          '### Top-tier reasoning (Architect / Senior Reviewer / Critical decisions)',
+          '- "claude-opus-4-7" — Anthropic flagship; deep reasoning, long-context, top code quality. PREFERRED for Architect / Reviewer.',
+          '- "gpt-5.5"        — OpenAI flagship; broad knowledge, strong system design, generalist. Great alternative for Architect.',
+          '- "claude-opus-4-6" — previous gen Opus; cheaper, still strong.',
+          '',
+          '### Balanced workhorse (main implementers; Backend / Generalist Dev)',
+          '- "composer-2"        — Cursor in-house balanced default; safe fallback.',
+          '- "claude-sonnet-4-6" — Anthropic mid-tier; much faster than Opus, good quality.',
+          '- "gpt-5.4"           — OpenAI mid-tier.',
+          '',
+          '### Code-specialised (pure refactor / codegen / Dev focused on code)',
+          '- "gpt-5.3-codex"     — OpenAI codex; excels at code edits.',
+          '- "gpt-5.1-codex-max" — long-context codex variant.',
+          '',
+          '### Multimodal / tool use / integration (Frontend with screenshots, QA, Integration)',
+          '- "gemini-3.1-pro"    — Google flagship; multimodal + grounding + tool use. PREFERRED for QA / Frontend / Integration.',
+          '- "gemini-3-flash"    — Google mid-tier, faster.',
+          '',
+          '### Lightweight (high-frequency simple tasks; cheap)',
+          '- "gpt-5-mini"        — OpenAI light',
+          '- "claude-haiku-4-5"  — Anthropic light',
+          '- "gemini-2.5-flash"  — Google ultra-fast',
+          '',
+          '## Selection guidelines',
+          '',
+          'Empirical observation as of 2026: Claude family generally outperforms others on raw coding & refactoring;',
+          "GPT family is broader generalist; Gemini family is best at multimodal & tool-use. Pick accordingly.",
+          '',
+          '- Architect / Designer / Lead Reviewer → claude-opus-4-7 (preferred) or gpt-5.5; thinking=true, context="1m", reasoning="high"~"extra-high"',
+          '- Code Reviewer / Security Reviewer  → claude-opus-4-7; thinking=true, context="1m", reasoning="high"',
+          '- Backend / Business Implementation  → claude-sonnet-4-6 (preferred for code quality) or composer-2; thinking=false, reasoning="medium"',
+          '- Pure code Dev (refactor / codegen) → claude-sonnet-4-6 (preferred) or gpt-5.3-codex; reasoning="medium"',
+          '- Frontend (UI / UX, possibly visual) → gemini-3.1-pro (multimodal) or claude-sonnet-4-6; thinking=false, reasoning="medium"',
+          '- QA / Integration / Tester          → gemini-3.1-pro (strong tool use & grounding); reasoning="medium"',
+          '- Generalist / PM-style coordinator  → gpt-5.5 (broad knowledge); reasoning="medium"',
+          '- Lightweight assistant role         → gpt-5-mini or claude-haiku-4-5; reasoning="low"',
+          '',
+          'Pair vendors deliberately. Typical strong shape: opus Architect + sonnet Backend Dev + gemini QA + opus Reviewer.',
+          "Don't overspend: only Architect / Reviewer should be on Opus-tier; implementers should be Sonnet/composer-2/codex.",
+        ];
 
   return [
     'You are the Team Architect for a new AI engineering team in Slark (a local AI Team OS).',
@@ -109,49 +179,7 @@ function buildTeamArchitectPrompt(input: SuggestTeamInput): string {
     `Workspace path: ${input.workspace_path}`,
     hintBlock,
     '',
-    '## Model catalog (Cursor SDK approved IDs only)',
-    '',
-    'Pick the right model for each role from this list — diversity is good (use vendors\' strengths together):',
-    '',
-    '### Top-tier reasoning (Architect / Senior Reviewer / Critical decisions)',
-    '- "claude-opus-4-7" — Anthropic flagship; deep reasoning, long-context, top code quality. PREFERRED for Architect / Reviewer.',
-    '- "gpt-5.5"        — OpenAI flagship; broad knowledge, strong system design, generalist. Great alternative for Architect.',
-    '- "claude-opus-4-6" — previous gen Opus; cheaper, still strong.',
-    '',
-    '### Balanced workhorse (main implementers; Backend / Generalist Dev)',
-    '- "composer-2"        — Cursor in-house balanced default; safe fallback.',
-    '- "claude-sonnet-4-6" — Anthropic mid-tier; much faster than Opus, good quality.',
-    '- "gpt-5.4"           — OpenAI mid-tier.',
-    '',
-    '### Code-specialised (pure refactor / codegen / Dev focused on code)',
-    '- "gpt-5.3-codex"     — OpenAI codex; excels at code edits.',
-    '- "gpt-5.1-codex-max" — long-context codex variant.',
-    '',
-    '### Multimodal / tool use / integration (Frontend with screenshots, QA, Integration)',
-    '- "gemini-3.1-pro"    — Google flagship; multimodal + grounding + tool use. PREFERRED for QA / Frontend / Integration.',
-    '- "gemini-3-flash"    — Google mid-tier, faster.',
-    '',
-    '### Lightweight (high-frequency simple tasks; cheap)',
-    '- "gpt-5-mini"        — OpenAI light',
-    '- "claude-haiku-4-5"  — Anthropic light',
-    '- "gemini-2.5-flash"  — Google ultra-fast',
-    '',
-    '## Selection guidelines',
-    '',
-    'Empirical observation as of 2026: Claude family generally outperforms others on raw coding & refactoring;',
-    "GPT family is broader generalist; Gemini family is best at multimodal & tool-use. Pick accordingly.",
-    '',
-    '- Architect / Designer / Lead Reviewer → claude-opus-4-7 (preferred) or gpt-5.5; thinking=true, context="1m", reasoning="high"~"extra-high"',
-    '- Code Reviewer / Security Reviewer  → claude-opus-4-7; thinking=true, context="1m", reasoning="high"',
-    '- Backend / Business Implementation  → claude-sonnet-4-6 (preferred for code quality) or composer-2; thinking=false, reasoning="medium"',
-    '- Pure code Dev (refactor / codegen) → claude-sonnet-4-6 (preferred) or gpt-5.3-codex; reasoning="medium"',
-    '- Frontend (UI / UX, possibly visual) → gemini-3.1-pro (multimodal) or claude-sonnet-4-6; thinking=false, reasoning="medium"',
-    '- QA / Integration / Tester          → gemini-3.1-pro (strong tool use & grounding); reasoning="medium"',
-    '- Generalist / PM-style coordinator  → gpt-5.5 (broad knowledge); reasoning="medium"',
-    '- Lightweight assistant role         → gpt-5-mini or claude-haiku-4-5; reasoning="low"',
-    '',
-    'Pair vendors deliberately. Typical strong shape: opus Architect + sonnet Backend Dev + gemini QA + opus Reviewer.',
-    "Don't overspend: only Architect / Reviewer should be on Opus-tier; implementers should be Sonnet/composer-2/codex.",
+    ...modelCatalog,
     '',
     'Reply with STRICT JSON ONLY. No markdown fences, no commentary, no prose.',
     'Schema:',
@@ -161,8 +189,8 @@ function buildTeamArchitectPrompt(input: SuggestTeamInput): string {
     '      "name": "Architect",                  // short, PascalCase or kebab-case',
     '      "role": "Architect",                   // one-word role label',
     '      "description": "...",                  // 1-3 sentences, written as the agent\'s system prompt in second person',
-    '      "runtime": "cursor",                   // always "cursor" for MVP',
-    '      "model": "claude-opus-4-7",            // pick from the catalog above',
+    `      "runtime": "${defaultRuntime}",                   // use "${defaultRuntime}" for this local setup`,
+    `      "model": "${defaultRuntime === 'codex' ? 'gpt-5.5' : 'claude-opus-4-7'}",            // pick from the catalog above`,
     '      "reasoning": "high",                   // low / medium / high / extra-high / max',
     '      "thinking": true,                      // true / false / null (null = model default)',
     '      "context": "1m"                        // "300k" / "1m" / null (null = model default)',
@@ -179,7 +207,7 @@ function buildTeamArchitectPrompt(input: SuggestTeamInput): string {
 // JSON 解析 + 兜底
 // =============================================================================
 
-function parseTeamSuggestion(raw: string): Omit<TeamSuggestion, 'is_fallback'> | null {
+function parseTeamSuggestion(raw: string, defaultRuntime: Runtime): Omit<TeamSuggestion, 'is_fallback'> | null {
   const cleaned = stripJSONFences(raw).trim();
   if (!cleaned) return null;
 
@@ -210,8 +238,8 @@ function parseTeamSuggestion(raw: string): Omit<TeamSuggestion, 'is_fallback'> |
     const description = typeof a.description === 'string' ? a.description.trim() : '';
     if (!name || !description) continue;
 
-    const runtime = typeof a.runtime === 'string' ? a.runtime.trim() : 'cursor';
-    const model = typeof a.model === 'string' ? a.model.trim() : 'composer-2';
+    const runtime = typeof a.runtime === 'string' ? a.runtime.trim() : defaultRuntime;
+    const model = typeof a.model === 'string' ? a.model.trim() : defaultModel(defaultRuntime, 'dev');
     // Phase B：reasoning 5 值；老 LLM 输出可能仍写 'xhigh'，在此 normalize 到 'extra-high'。
     const reasoningRaw = typeof a.reasoning === 'string' ? a.reasoning.trim() : 'medium';
     const reasoning: ReasoningEffort =
@@ -225,8 +253,7 @@ function parseTeamSuggestion(raw: string): Omit<TeamSuggestion, 'is_fallback'> |
           ? 'extra-high'
           : 'medium';
 
-    // 只接受 'cursor' 或 '' 作为 MVP runtime；其他置 'cursor'
-    const runtimeNormalized = runtime === 'cursor' ? 'cursor' : 'cursor';
+    const runtimeNormalized = runtime === 'cursor' || runtime === 'codex' ? runtime : defaultRuntime;
 
     // Sprint 4-ext / Phase A：thinking / context 接受多种 LLM 输出变体
     const thinking = parseThinking(a.thinking);
@@ -237,7 +264,7 @@ function parseTeamSuggestion(raw: string): Omit<TeamSuggestion, 'is_fallback'> |
       role: role || name,
       description,
       runtime: runtimeNormalized,
-      model: model || 'composer-2',
+      model: model || defaultModel(runtimeNormalized, 'dev'),
       reasoning,
       thinking,
       context,
@@ -295,52 +322,57 @@ function parseContext(raw: unknown): import('@slark/shared').ContextSize | null 
 // 兜底三件套（Q-2 / Review 5）
 // =============================================================================
 
-// Sprint 4-ext / Phase A：兜底三件套也按角色配合理的 model + thinking + context，
-// 让 cursor backend 不可用时用户在 Profile 看到的 default 配置仍然 sensible。
-// 不再写空字符串让用户填，因为 SDK 模式下用户都已经配过 backend，model 字段就该有值。
-const FALLBACK_ARCHITECT: TeamSuggestionAgent = {
-  name: 'Architect',
-  role: 'Architect',
-  description:
-    'You design APIs, data models, and module boundaries. Before proposing a solution, skim the codebase to understand existing conventions. Focus on clarity and maintainability over cleverness.',
-  runtime: 'cursor',
-  model: 'claude-opus-4-7',
-  reasoning: 'high',
-  thinking: true,
-  context: '1m',
-};
-
-const FALLBACK_DEV: TeamSuggestionAgent = {
-  name: 'Dev',
-  role: 'Developer',
-  description:
-    "You implement features based on the Architect's design. Write clean, typed code with tests. Always wrap async calls in try/catch and surface errors with structured context.",
-  runtime: 'cursor',
-  // Sprint 4-ext / Phase A：Sonnet 4.6 在编码实现 / 重构上整体优于同档通用模型，适合 Dev 主力。
-  model: 'claude-sonnet-4-6',
-  reasoning: 'medium',
-  thinking: false,
-  context: null,
-};
-
-const FALLBACK_REVIEWER: TeamSuggestionAgent = {
-  name: 'Reviewer',
-  role: 'Reviewer',
-  description:
-    'You review code for correctness, security, and maintainability. Call out issues directly and suggest concrete fixes. Do not rubber-stamp; push back when something feels off.',
-  runtime: 'cursor',
-  model: 'claude-opus-4-7',
-  reasoning: 'high',
-  thinking: true,
-  context: '1m',
-};
-
-function fallbackTeam(reason: string): TeamSuggestion {
+function fallbackTeam(defaultRuntime: Runtime, reason: string): TeamSuggestion {
   return {
-    agents: [FALLBACK_ARCHITECT, FALLBACK_DEV, FALLBACK_REVIEWER],
+    agents: fallbackAgents(defaultRuntime),
     rationale:
       'Default team (Team Architect unavailable). Please configure runtime/model for each agent before use.',
     is_fallback: true,
     fallback_reason: reason,
   };
+}
+
+function fallbackAgents(runtime: Runtime): TeamSuggestionAgent[] {
+  return [
+    {
+      name: 'Architect',
+      role: 'Architect',
+      description:
+        'You design APIs, data models, and module boundaries. Before proposing a solution, skim the codebase to understand existing conventions. Focus on clarity and maintainability over cleverness.',
+      runtime,
+      model: defaultModel(runtime, 'architect'),
+      reasoning: 'high',
+      thinking: runtime === 'cursor' ? true : null,
+      context: runtime === 'cursor' ? '1m' : null,
+    },
+    {
+      name: 'Dev',
+      role: 'Developer',
+      description:
+        "You implement features based on the Architect's design. Write clean, typed code with tests. Always wrap async calls in try/catch and surface errors with structured context.",
+      runtime,
+      model: defaultModel(runtime, 'dev'),
+      reasoning: 'medium',
+      thinking: runtime === 'cursor' ? false : null,
+      context: null,
+    },
+    {
+      name: 'Reviewer',
+      role: 'Reviewer',
+      description:
+        'You review code for correctness, security, and maintainability. Call out issues directly and suggest concrete fixes. Do not rubber-stamp; push back when something feels off.',
+      runtime,
+      model: defaultModel(runtime, 'reviewer'),
+      reasoning: 'high',
+      thinking: runtime === 'cursor' ? true : null,
+      context: runtime === 'cursor' ? '1m' : null,
+    },
+  ];
+}
+
+function defaultModel(runtime: Runtime, role: 'architect' | 'dev' | 'reviewer'): string {
+  if (runtime === 'codex') {
+    return role === 'dev' ? 'gpt-5.3-codex' : 'gpt-5.5';
+  }
+  return role === 'dev' ? 'claude-sonnet-4-6' : 'claude-opus-4-7';
 }

--- a/packages/web/src/components/CreateProjectDialog.tsx
+++ b/packages/web/src/components/CreateProjectDialog.tsx
@@ -137,12 +137,11 @@ export function CreateProjectDialog({ open, onClose }: Props) {
       });
       upsertChannel(channel);
 
-      // 3. 批量创建 Agents（跳过 fallback 中 runtime 为空的；fallback 时走下面的分支）
+      // 3. 批量创建 Agents
       const createdAgents = await Promise.all(
         suggestion.agents.map(async (a) => {
-          // 兜底 runtime 为空的 Agent 也要创建，但写 'cursor' 作为占位（用户 Approve 后还需编辑）
-          // 若 Runtime 下拉在 CreateAgentDialog 里限制未装则 disabled；这里先允许创建，
-          // 用户在 DM 中 @Agent 时若 runtime 不可用会看到 system error，符合 Q-2 预期降级
+          // 兜底 runtime 为空的 Agent 也要创建，但写 'cursor' 作为占位（用户 Approve 后还需编辑）。
+          // 如果后端检测到 Codex 可用，fallback/suggestion 会直接返回 runtime='codex'。
           const runtime = a.runtime || 'cursor';
           const payload = {
             name: ensureUniqueName(a.name),
@@ -389,7 +388,7 @@ function Step2({
             Team Architect is analyzing your goal…
           </div>
           <div className="text-[11px] font-mono text-text-secondary mt-2">
-            Spawning cursor-agent (timeout 30s)
+            Spawning local coding runtime (timeout 30s)
           </div>
         </div>
       )}


### PR DESCRIPTION
> Stacked follow-up PR: this depends on #2. Please merge/review #2 first, then review this PR.

Hi, this is a follow-up to #2. It keeps the Codex adapter plumbing separate and focuses only on using the available local coding runtime for Slark system agents.

What changed:
- Added `createSystemAdapter()` as the shared system-agent runtime selector.
- Added `SLARK_SYSTEM_RUNTIME=cursor|codex` as an explicit override.
- Defaults to Cursor when available, falls back to Codex when Cursor is unavailable, and otherwise preserves the existing Cursor fallback behavior.
- Updated Coach, Evaluator, Facilitator, Onboarder, Scribe, and Team Architect to use the system adapter selector.
- Updated Team Architect prompts/fallback suggestions so generated agents use the selected runtime (`cursor` or `codex`) and matching model defaults.
- Updated the create-project loading copy from `cursor-agent` to local coding runtime.

Why separate:
- #2 only adds the Codex adapter and regular agent runtime wiring.
- This PR changes higher-level system-agent behavior, so it is easier to review independently after #2 lands.

Local verification:
- `npm exec --yes -- pnpm typecheck`
- `npm exec --yes -- pnpm build:server`
- `npm exec --yes -- pnpm build:web`
- `git diff --check`

Note:
- This PR should be merged after #2.
- I kept Cursor as the preferred default when it is available, so existing Cursor-based behavior should remain unchanged unless Cursor is unavailable or `SLARK_SYSTEM_RUNTIME=codex` is set.
